### PR TITLE
feat: schedule 및 user 테이블 생성

### DIFF
--- a/src/main/java/com/example/upgradedschedule/UpgradedScheduleApplication.java
+++ b/src/main/java/com/example/upgradedschedule/UpgradedScheduleApplication.java
@@ -2,6 +2,7 @@ package com.example.upgradedschedule;
 
 import org.springframework.boot.SpringApplication;
 import org.springframework.boot.autoconfigure.SpringBootApplication;
+import org.springframework.boot.autoconfigure.domain.EntityScan;
 import org.springframework.data.jpa.repository.config.EnableJpaAuditing;
 
 @EnableJpaAuditing

--- a/src/main/java/com/example/upgradedschedule/entity/BaseEntity.java
+++ b/src/main/java/com/example/upgradedschedule/entity/BaseEntity.java
@@ -1,0 +1,22 @@
+package com.example.upgradedschedule.entity;
+
+import jakarta.persistence.EntityListeners;
+import jakarta.persistence.MappedSuperclass;
+import lombok.Getter;
+import org.springframework.data.annotation.CreatedDate;
+import org.springframework.data.annotation.LastModifiedDate;
+import org.springframework.data.jpa.domain.support.AuditingEntityListener;
+
+import java.time.LocalDateTime;
+
+@Getter
+@MappedSuperclass
+@EntityListeners(AuditingEntityListener.class)
+public abstract class BaseEntity {
+
+    @CreatedDate
+    private LocalDateTime createdAt;
+
+    @LastModifiedDate
+    private LocalDateTime modifiedAt;
+}

--- a/src/main/java/com/example/upgradedschedule/entity/Schedule.java
+++ b/src/main/java/com/example/upgradedschedule/entity/Schedule.java
@@ -1,0 +1,40 @@
+package com.example.upgradedschedule.entity;
+
+
+import jakarta.persistence.*;
+import lombok.AllArgsConstructor;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+import lombok.Setter;
+
+import java.time.LocalDateTime;
+
+@Getter
+@AllArgsConstructor
+@NoArgsConstructor
+@Setter
+@Entity
+@Table(name = "schedule")
+public class Schedule extends BaseEntity {
+
+    @Id
+    @GeneratedValue(strategy = GenerationType.IDENTITY)
+    private Long scheduleId;
+
+    @Column(nullable = false)
+    private String title;
+
+    @Column(nullable = false)
+    private String content;
+
+    @Column(nullable = false)
+    private String schedulePassword;
+
+    @Column(nullable = false)
+    private LocalDateTime scheduleDate;
+
+    @ManyToOne
+    @JoinColumn(name="user_id")
+    private User user;
+
+}

--- a/src/main/java/com/example/upgradedschedule/entity/User.java
+++ b/src/main/java/com/example/upgradedschedule/entity/User.java
@@ -1,0 +1,36 @@
+package com.example.upgradedschedule.entity;
+
+import jakarta.persistence.*;
+import lombok.AllArgsConstructor;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+import lombok.Setter;
+
+import java.util.ArrayList;
+import java.util.List;
+
+@Getter
+@Setter
+@AllArgsConstructor
+@NoArgsConstructor
+@Entity
+@Table(name = "user")
+public class User extends BaseEntity {
+
+    @Id
+    @GeneratedValue(strategy = GenerationType.IDENTITY)
+    private Long userId;
+
+    @Column(nullable = false, unique = true)
+    private String userEmail;
+
+    @Column(nullable = false)
+    private String userName;
+
+    @Column(nullable = false)
+    private String userPassword;
+
+    @OneToMany(mappedBy = "user")
+    private List<Schedule> schedules = new ArrayList<>();
+
+}

--- a/src/main/resources/application.properties
+++ b/src/main/resources/application.properties
@@ -1,7 +1,7 @@
 spring.application.name=upgradedSchedule
 
 
-spring.datasource.url=jdbc:mysql://localhost:3306/schedule
+spring.datasource.url=jdbc:mysql://localhost:3306/schedule2
 spring.datasource.username=root
 spring.datasource.password=12341234
 spring.datasource.driver-class-name=com.mysql.cj.jdbc.Driver


### PR DESCRIPTION
### 📌 변경 사항  
- `User` 엔티티 추가 (`user_id`, `user_email`, `user_name`, `user_password`)  
- `Schedule` 엔티티 추가 (`schedule_id`, `title`, `content`, `schedule_password`, `schedule_date`)  
- `User`와 `Schedule` 간 **1:N 관계** 설정 (`User` 기준으로 `OneToMany`, `Schedule` 기준으로 `ManyToOne`)  
- `BaseEntity`를 상속하여 **생성일(createdAt), 수정일(updatedAt) 자동 관리**  

### 📝 생성된 테이블 (DDL)  
```sql
-- User 테이블 생성
CREATE TABLE user (
    user_id BIGINT AUTO_INCREMENT PRIMARY KEY,
    user_email VARCHAR(255) NOT NULL UNIQUE,
    user_name VARCHAR(255) NOT NULL,
    user_password VARCHAR(255) NOT NULL,
    created_at TIMESTAMP DEFAULT CURRENT_TIMESTAMP,
    updated_at TIMESTAMP DEFAULT CURRENT_TIMESTAMP ON UPDATE CURRENT_TIMESTAMP
);

-- Schedule 테이블 생성
CREATE TABLE schedule (
    schedule_id BIGINT AUTO_INCREMENT PRIMARY KEY,
    title VARCHAR(255) NOT NULL,
    content TEXT NOT NULL,
    schedule_password VARCHAR(255) NOT NULL,
    schedule_date DATETIME NOT NULL,
    user_id BIGINT,
    created_at TIMESTAMP DEFAULT CURRENT_TIMESTAMP,
    updated_at TIMESTAMP DEFAULT CURRENT_TIMESTAMP ON UPDATE CURRENT_TIMESTAMP,
    CONSTRAINT fk_schedule_user FOREIGN KEY (user_id) REFERENCES user(user_id) ON DELETE CASCADE
);