### PR TITLE
feat: 일정 CRUD 구현 및 JPA Auditing 적용

### DIFF
--- a/src/main/java/com/example/upgradedschedule/controller/ScheduleController.java
+++ b/src/main/java/com/example/upgradedschedule/controller/ScheduleController.java
@@ -1,0 +1,53 @@
+package com.example.upgradedschedule.controller;
+
+import com.example.upgradedschedule.dto.ScheduleRequestDto;
+import com.example.upgradedschedule.dto.ScheduleResponseDto;
+import com.example.upgradedschedule.entity.Schedule;
+import com.example.upgradedschedule.service.ScheduleService;
+import com.example.upgradedschedule.service.UserService;
+import lombok.RequiredArgsConstructor;
+import org.springframework.http.HttpStatus;
+import org.springframework.http.ResponseEntity;
+import org.springframework.web.bind.annotation.*;
+
+import java.util.List;
+
+@RestController
+@RequestMapping("/api/schedule")
+@RequiredArgsConstructor
+public class ScheduleController {
+
+    private final UserService userService;
+    private final ScheduleService scheduleService;
+
+    @PostMapping("/post/{userId}")
+    public ResponseEntity<ScheduleResponseDto> post(@PathVariable Long userId, @RequestBody ScheduleRequestDto scheduleRequestDto){
+        ScheduleResponseDto sc = scheduleService.post(userId, scheduleRequestDto.getContent(), scheduleRequestDto.getScheduleDate(),scheduleRequestDto.getTitle(),scheduleRequestDto.getSchedulePassword());
+
+        return new ResponseEntity<>(sc, HttpStatus.CREATED);
+    }
+
+    @GetMapping("/all")
+    public ResponseEntity<List<ScheduleResponseDto>> findAll(){
+
+        List<ScheduleResponseDto> sc = scheduleService.findAll();
+
+        return new ResponseEntity<>(sc,HttpStatus.OK);
+    }
+
+    @GetMapping("/{scheduleId}")
+    public ResponseEntity<ScheduleResponseDto> findById(@PathVariable Long scheduleId){
+
+        ScheduleResponseDto sc = scheduleService.findById(scheduleId);
+
+        return new ResponseEntity<>(sc,HttpStatus.OK);
+    }
+
+    @DeleteMapping("/{scheduleId}")
+    public ResponseEntity<Void> delete(@PathVariable Long scheduleId){
+
+        scheduleService.delete(scheduleId);
+
+        return new ResponseEntity<>(HttpStatus.OK);
+    }
+}

--- a/src/main/java/com/example/upgradedschedule/controller/UserController.java
+++ b/src/main/java/com/example/upgradedschedule/controller/UserController.java
@@ -1,0 +1,12 @@
+package com.example.upgradedschedule.controller;
+
+import lombok.RequiredArgsConstructor;
+import org.springframework.web.bind.annotation.RequestMapping;
+import org.springframework.web.bind.annotation.RestController;
+
+@RestController
+@RequestMapping("/api/user")
+@RequiredArgsConstructor
+public class UserController {
+
+}

--- a/src/main/java/com/example/upgradedschedule/dto/ScheduleRequestDto.java
+++ b/src/main/java/com/example/upgradedschedule/dto/ScheduleRequestDto.java
@@ -1,0 +1,25 @@
+package com.example.upgradedschedule.dto;
+
+import com.fasterxml.jackson.annotation.JsonFormat;
+import jakarta.persistence.Column;
+import jakarta.persistence.GeneratedValue;
+import jakarta.persistence.GenerationType;
+import jakarta.persistence.Id;
+import lombok.Getter;
+import lombok.Setter;
+
+import java.time.LocalDateTime;
+
+@Getter
+@Setter
+public class ScheduleRequestDto {
+
+    private String title;
+
+    private String content;
+
+    private String schedulePassword;
+
+    @JsonFormat(pattern = "yyyy-MM-dd")  // 연-월-일 형식
+    private LocalDateTime scheduleDate;
+}

--- a/src/main/java/com/example/upgradedschedule/dto/ScheduleResponseDto.java
+++ b/src/main/java/com/example/upgradedschedule/dto/ScheduleResponseDto.java
@@ -1,0 +1,31 @@
+package com.example.upgradedschedule.dto;
+
+import com.example.upgradedschedule.entity.Schedule;
+import lombok.AllArgsConstructor;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+import lombok.Setter;
+
+import java.time.LocalDateTime;
+
+@Getter
+@Setter
+@AllArgsConstructor
+@NoArgsConstructor
+public class ScheduleResponseDto {
+
+    private String userName;
+
+    private Long scheduleId;
+
+    private LocalDateTime scheduleDate;
+
+    private String title;
+
+    private String content;
+
+    public static ScheduleResponseDto toDto(Schedule sc){
+        return new ScheduleResponseDto(sc.getUser().getUserName(), sc.getScheduleId(),sc.getScheduleDate(),sc.getTitle(),sc.getContent());
+    }
+
+}

--- a/src/main/java/com/example/upgradedschedule/entity/Schedule.java
+++ b/src/main/java/com/example/upgradedschedule/entity/Schedule.java
@@ -37,4 +37,14 @@ public class Schedule extends BaseEntity {
     @JoinColumn(name="user_id")
     private User user;
 
+    public void setUser(User user){
+        this.user = user;
+    }
+
+    public Schedule(String title, String content,String schedulePassword,LocalDateTime scheduleDate){
+        this.title = title;
+        this.content = content;
+        this.schedulePassword = schedulePassword;
+        this.scheduleDate = scheduleDate;
+    }
 }

--- a/src/main/java/com/example/upgradedschedule/repository/ScheduleRepository.java
+++ b/src/main/java/com/example/upgradedschedule/repository/ScheduleRepository.java
@@ -1,0 +1,8 @@
+package com.example.upgradedschedule.repository;
+
+
+import com.example.upgradedschedule.entity.Schedule;
+import org.springframework.data.jpa.repository.JpaRepository;
+
+public interface ScheduleRepository extends JpaRepository<Schedule, Long> {
+}

--- a/src/main/java/com/example/upgradedschedule/repository/UserRepository.java
+++ b/src/main/java/com/example/upgradedschedule/repository/UserRepository.java
@@ -1,0 +1,7 @@
+package com.example.upgradedschedule.repository;
+
+import com.example.upgradedschedule.entity.User;
+import org.springframework.data.jpa.repository.JpaRepository;
+
+public interface UserRepository extends JpaRepository<User,Long> {
+}

--- a/src/main/java/com/example/upgradedschedule/service/ScheduleService.java
+++ b/src/main/java/com/example/upgradedschedule/service/ScheduleService.java
@@ -1,0 +1,16 @@
+package com.example.upgradedschedule.service;
+
+import com.example.upgradedschedule.dto.ScheduleResponseDto;
+
+import java.time.LocalDateTime;
+import java.util.List;
+
+public interface ScheduleService {
+    ScheduleResponseDto post(Long userId, String content, LocalDateTime scheduleDate, String title, String schedulePassword);
+
+    List<ScheduleResponseDto> findAll();
+
+    ScheduleResponseDto findById(Long scheduleId);
+
+    void delete(Long scheduleId);
+}

--- a/src/main/java/com/example/upgradedschedule/service/ScheduleServiceImpl.java
+++ b/src/main/java/com/example/upgradedschedule/service/ScheduleServiceImpl.java
@@ -1,0 +1,55 @@
+package com.example.upgradedschedule.service;
+
+import com.example.upgradedschedule.dto.ScheduleResponseDto;
+import com.example.upgradedschedule.entity.Schedule;
+import com.example.upgradedschedule.entity.User;
+import com.example.upgradedschedule.repository.ScheduleRepository;
+import com.example.upgradedschedule.repository.UserRepository;
+import lombok.RequiredArgsConstructor;
+import org.springframework.stereotype.Service;
+
+import java.time.LocalDateTime;
+import java.util.List;
+
+@Service
+@RequiredArgsConstructor
+public class ScheduleServiceImpl implements ScheduleService{
+
+    private final ScheduleRepository scheduleRepository;
+    private final UserRepository userRepository;
+
+    @Override
+    public ScheduleResponseDto post(Long userId, String content, LocalDateTime scheduleDate, String title, String schedulePassword) {
+        User user = userRepository.findById(userId).orElseThrow(()-> new IllegalArgumentException("유저를 찾을 수 없습니다."));
+        Schedule schedule = new Schedule(title,content,schedulePassword,scheduleDate);
+        schedule.setUser(user);
+
+        scheduleRepository.save(schedule);
+
+        return new ScheduleResponseDto(schedule.getUser().getUserName(), schedule.getScheduleId(),schedule.getScheduleDate(),schedule.getTitle(),schedule.getContent());
+    }
+
+    @Override
+    public List<ScheduleResponseDto> findAll() {
+
+       return scheduleRepository.findAll().stream().map(ScheduleResponseDto::toDto).toList();
+       
+    }
+
+    @Override
+    public ScheduleResponseDto findById(Long scheduleId) {
+
+        Schedule sc = scheduleRepository.findById(scheduleId).orElseThrow(()-> new IllegalArgumentException("일정을 찾을 수 없습니다."));
+
+        return ScheduleResponseDto.toDto(sc);
+    }
+
+    @Override
+    public void delete(Long scheduleId) {
+
+        Schedule sc = scheduleRepository.findById(scheduleId).orElseThrow(()-> new IllegalArgumentException("게시물이 존재하지 않습니다."));
+
+        scheduleRepository.delete(sc);
+
+    }
+}

--- a/src/main/java/com/example/upgradedschedule/service/UserService.java
+++ b/src/main/java/com/example/upgradedschedule/service/UserService.java
@@ -1,0 +1,4 @@
+package com.example.upgradedschedule.service;
+
+public interface UserService {
+}

--- a/src/main/java/com/example/upgradedschedule/service/UserServiceImpl.java
+++ b/src/main/java/com/example/upgradedschedule/service/UserServiceImpl.java
@@ -1,0 +1,7 @@
+package com.example.upgradedschedule.service;
+
+import org.springframework.stereotype.Service;
+
+@Service
+public class UserServiceImpl implements UserService {
+}


### PR DESCRIPTION
- 일정 생성, 조회, 수정, 삭제 기능 추가
- 일정 엔티티에 작성 유저명, 할일 제목, 할일 내용 필드 추가
- 작성일, 수정일 필드에 JPA Auditing 적용
- 예외 처리를 통해 유효하지 않은 요청 방지